### PR TITLE
Added a note on usage of textarea element

### DIFF
--- a/src/Html.elm
+++ b/src/Html.elm
@@ -774,7 +774,9 @@ option =
   node "option"
 
 
-{-| Represents a multiline text edit control. -}
+{-| Represents a multiline text edit control. NOTE: to set contents of a dynamic
+`textarea` use the `value` attribute instead of adding child elements to the `textarea`. 
+-}
 textarea : List (Attribute msg) -> List (Html msg) -> Html msg
 textarea =
   node "textarea"


### PR DESCRIPTION
Maybe everyone else just knew about how to properly use textarea elements, but I spent half an hour trying the wrong way and got bit frustrated with them. 

Setting the text area contents through child elements fails when the textarea elements are removed.  Regardless of which element is removed, the content of the last text area vanishes and the remaining text areas get the previous contents in the original order. That is, the textarea contents jump from one element to another.
