### PR TITLE
Document breaking change in Html.node function

### DIFF
--- a/src/Html.elm
+++ b/src/Html.elm
@@ -118,6 +118,8 @@ functions in this library.
 
 You can use this to create custom nodes if you need to create something that
 is not covered by the helper functions in this library.
+
+`script` nodes are transformed to `p` nodes as they are a possible XSS attack vector.
 -}
 node : String -> List (Attribute msg) -> List (Html msg) -> Html msg
 node =


### PR DESCRIPTION
This worked for the old `html` package.

Just documenting the change so that no one trips over it, as the compiler just runs with it and there are no runtime-errors as well.

If I understand it correctly the relevant change happens [here](https://github.com/elm/virtual-dom/blob/master/src/Elm/Kernel/VirtualDom.js#L277).
So the documentation would be exhaustive.