### PR TITLE
Add comments for h1, h6

### DIFF
--- a/src/Html.elm
+++ b/src/Html.elm
@@ -205,7 +205,8 @@ aside =
   Elm.Kernel.VirtualDom.node "aside"
 
 
-{-|-}
+{-| Defines a heading of maximum importance to the document.
+-}
 h1 : List (Attribute msg) -> List (Html msg) -> Html msg
 h1 =
   Elm.Kernel.VirtualDom.node "h1"
@@ -235,7 +236,8 @@ h5 =
   Elm.Kernel.VirtualDom.node "h5"
 
 
-{-|-}
+{-| Defines a heading of least importance to the document.
+-}
 h6 : List (Attribute msg) -> List (Html msg) -> Html msg
 h6 =
   Elm.Kernel.VirtualDom.node "h6"


### PR DESCRIPTION
`h1` seemed lonely. And `h6` was its polar opposite. So I wrote comments for both.

I'm not sure how to describe `h2` through `h5`, except in terms of e.g. "slightly less important than `h1` but not as unimportant as `h3`" which is more than a little redundant.