### PR TITLE
Warn users 'button' will submit the form by default

### DIFF
--- a/src/Html.elm
+++ b/src/Html.elm
@@ -758,7 +758,10 @@ input =
   Elm.Kernel.VirtualDom.node "input"
 
 
-{-| Represents a button. -}
+{-| Represents a button. By default this is an HTML input element with type
+'submit' and will thus submit enclosing form. To prevent this, the attribute
+`type_ "button"` can be used.
+-}
 button : List (Attribute msg) -> List (Html msg) -> Html msg
 button =
   Elm.Kernel.VirtualDom.node "button"


### PR DESCRIPTION
By default `Html.button` is an input of type 'submit'.
This may be yield surprising results when using the
`onClick` attribute on a button, effectively firing two
events (one for the click and another one for the
form submit).

This commit adds a word of caution in the `button`
element documentation to warn users of this
behavior and how to prevent it.