### PR TITLE
Add dialog html tag.

### DIFF
--- a/src/Html.elm
+++ b/src/Html.elm
@@ -6,7 +6,7 @@ module Html exposing
   , span, a, code, em, strong, i, b, u, sub, sup, br
   , ol, ul, li, dl, dt, dd
   , img, iframe, canvas, math
-  , form, input, textarea, button, select, option
+  , form, input, textarea, button, select, option, dialog
   , section, nav, article, aside, header, footer, address, main_
   , figure, figcaption
   , table, caption, colgroup, col, tbody, thead, tfoot, tr, td, th
@@ -843,3 +843,9 @@ menu : List (Attribute msg) -> List (Html msg) -> Html msg
 menu =
   Elm.Kernel.VirtualDom.node "menu"
 
+
+{-| Represents a dialog box or other interactive component, 
+such as a dismissible alert, inspector, or subwindow. -}
+dialog : List (Attribute msg) -> List (Html msg) -> Html msg
+dialog =
+  Elm.Kernel.VirtualDom.node "dialog"


### PR DESCRIPTION
Recently, the super useful HTML tag <dialog> get full support as you can see: 

 - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
 - https://caniuse.com/?search=dialog%20
 
 So, I made this as an open-source contribution.