### PR TITLE
add new "dialog" element

### DIFF
--- a/src/Html.elm
+++ b/src/Html.elm
@@ -17,6 +17,7 @@ module Html exposing
   , small, cite, dfn, abbr, time, var, samp, kbd, s, q
   , mark, ruby, rt, rp, bdi, bdo, wbr
   , details, summary, menuitem, menu
+  , dialog
   )
 
 {-| This file is organized roughly in order of popularity. The tags which you'd
@@ -843,3 +844,8 @@ menu : List (Attribute msg) -> List (Html msg) -> Html msg
 menu =
   Elm.Kernel.VirtualDom.node "menu"
 
+
+{-| Represents a dialog that can be shown to the user. -}
+dialog : List (Attribute msg) -> List (Html msg) -> Html msg
+dialog =
+  Elm.Kernel.VirtualDom.node "dialog"

--- a/src/Html/Attributes.elm
+++ b/src/Html/Attributes.elm
@@ -17,6 +17,7 @@ module Html.Attributes exposing
   , accesskey, contenteditable, contextmenu, dir, draggable, dropzone
   , itemprop, lang, spellcheck, tabindex
   , cite, datetime, pubdate, manifest
+  , open
   )
 
 {-| Helper functions for HTML attributes. They are organized roughly by
@@ -899,6 +900,12 @@ scope =
 manifest : String -> Attribute msg
 manifest =
   Elm.Kernel.VirtualDom.attribute "manifest"
+
+
+{-| Indicates whether a `dialog` element is visible or not. -}
+open : Bool -> Attribute msg
+open =
+  boolProperty "open"
 
 
 {-- TODO: maybe reintroduce once there's a better way to disambiguate imports


### PR DESCRIPTION
This commit adds the dialog element and the open-property that is used to indicate whether it should be visible to the user or not.

Link: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog